### PR TITLE
Updated s3 bucket output attribute from name, to bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.1 (18/12/2017)
+
+ * Remove `-upgrade` from init. Added prematurely. Can go back in when 0.9 support is dropped.
+
 ## 1.4.0 (18/12/2017)
 
  * Support terraform 0.10/0.11, bypassing new built-in approval mechanism.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.0 (18/12/2017)
+
+ * Support terraform 0.10/0.11, bypassing new built-in approval mechanism.
+ * Explicitly cache plugin downloads.
+ * Set TF_IN_AUTOMATION.
+
 ## 1.3.1 (27/07/2017)
 
  * Change from error to warn on non-presence of requested group variables file

--- a/bin/terraform.sh
+++ b/bin/terraform.sh
@@ -8,7 +8,7 @@
 ##
 # Set Script Version
 ##
-readonly script_ver="1.4.0";
+readonly script_ver="1.4.1";
 
 ##
 # Standardised failure function
@@ -572,7 +572,8 @@ if [ "${bootstrapped}" == "true" ]; then
  
   # Configure remote state storage
   echo "Setting up S3 remote state from s3://${bucket}/${backend_key}";
-  terraform init -upgrade \
+  # TODO: Add -upgrade to init when we drop support for <0.10
+  terraform init \
     || error_and_die "Terraform init failed";
 fi;
 
@@ -661,7 +662,8 @@ case "${action}" in
         trap "rm -f $(pwd)/backend_terraformscaffold.tf" EXIT;
 
         # Push Terraform Remote State to S3
-        echo "yes" | terraform init -upgrade || error_and_die "Terraform init failed";
+        # TODO: Add -upgrade to init when we drop support for <0.10
+        echo "yes" | terraform init || error_and_die "Terraform init failed";
 
         # Hard cleanup
         rm -f backend_terraformscaffold.tf;

--- a/bootstrap/s3_bucket.tf
+++ b/bootstrap/s3_bucket.tf
@@ -37,5 +37,5 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 output "bucket_name" {
-  value = "${aws_s3_bucket.bucket.name}"
+  value = "${aws_s3_bucket.bucket.bucket}"
 }


### PR DESCRIPTION
Looks like the name output attribute of an S3 bucket has changed from name, to bucket.