### PR TITLE
Updated to allow bootstrap to work with terraform 0.12.21

### DIFF
--- a/bootstrap/s3_bucket.tf
+++ b/bootstrap/s3_bucket.tf
@@ -29,11 +29,11 @@ resource "aws_s3_bucket" "bucket" {
 
   # This does not use default tag map merging because bootstrapping is special
   # You should use default tag map merging elsewhere
-  tags {
-    "Name"        = "Terraform Scaffold State File Bucket for account ${var.aws_account_id} in region ${var.region}"
-    "Environment" = "${var.environment}"
-    "Project"     = "${var.project}"
-    "Component"   = "${var.component}"
-    "Account"     = "${var.aws_account_id}"
+  tags = {
+    Name        = "Terraform Scaffold State File Bucket for account ${var.aws_account_id} in region ${var.region}"
+    Environment = "${var.environment}"
+    Project     = "${var.project}"
+    Component   = "${var.component}"
+    Account     = "${var.aws_account_id}"
   }
 }


### PR DESCRIPTION
Bootstrap was previously failing due to syntax changes in terraform affecting s3_bucket.