### PR TITLE
TF15 - destroy force flag has been removed

### DIFF
--- a/bin/terraform.sh
+++ b/bin/terraform.sh
@@ -337,11 +337,11 @@ case "${action}" in
     ;;
   destroy)
     destroy='-destroy';
-    if [ $(terraform version | head -n1 | cut -d" " -f2 | cut -d"." -f2) -lt 15 ]; then
+    if [ $(terraform version | head -n1 | cut -d" " -f2 | cut -d"." -f1) == "v0" ] && [ $(terraform version | head -n1 | cut -d" " -f2 | cut -d"." -f2) -lt 15 ]; then
       echo "Compatibility: Adding to terraform arguments: -force";
       force='-force';
     else
-    extra_args+=" -auto-approve";
+      extra_args+=" -auto-approve";
     fi;
     refresh="-refresh=true";
     ;;


### PR DESCRIPTION
Terraform 0.14 deprecated -force flag for destroy action and 0.15 totally removed it.

This is simple and dirty update to maintain compatibility with previous versions.

Terraform 0.15 errors out with:
```
Terraform has been successfully initialized!
╷
│ Error: Failed to parse command-line flags
│ 
│ flag provided but not defined: -force
╵

For more help on using this command, run:
  terraform destroy -help
ERROR: Terraform destroy failed with exit code 1
```